### PR TITLE
add _authorUrl and _publishUrl

### DIFF
--- a/ui.content/src/main/content/jcr_root/conf/wknd-shared/settings/graphql/persistentQueries/adventure-by-path/_jcr_content/_jcr_data.binary
+++ b/ui.content/src/main/content/jcr_root/conf/wknd-shared/settings/graphql/persistentQueries/adventure-by-path/_jcr_content/_jcr_data.binary
@@ -21,6 +21,7 @@ query getAdventureByPath($adventurePath: String!) {
         ...on ImageRef {
           _path
           _authorUrl
+          _publishUrl
           width
           height
           mimeType

--- a/ui.content/src/main/content/jcr_root/conf/wknd-shared/settings/graphql/persistentQueries/adventure-by-price/_jcr_content/_jcr_data.binary
+++ b/ui.content/src/main/content/jcr_root/conf/wknd-shared/settings/graphql/persistentQueries/adventure-by-price/_jcr_content/_jcr_data.binary
@@ -25,6 +25,8 @@ query filterAdventuresByPrice($price: Float!, $priceOperator: FloatOperator!) {
       primaryImage {
         ... on ImageRef {
           _path
+          _authorUrl
+          _publishUrl
           mimeType
           width
           height

--- a/ui.content/src/main/content/jcr_root/conf/wknd-shared/settings/graphql/persistentQueries/adventure-by-slug/_jcr_content/_jcr_data.binary
+++ b/ui.content/src/main/content/jcr_root/conf/wknd-shared/settings/graphql/persistentQueries/adventure-by-slug/_jcr_content/_jcr_data.binary
@@ -24,6 +24,8 @@ query($slug: String!) {
       primaryImage {
         ... on ImageRef {
           _path
+          _authorUrl
+          _publishUrl
           mimeType
           width
           height

--- a/ui.content/src/main/content/jcr_root/conf/wknd-shared/settings/graphql/persistentQueries/adventures-all/_jcr_content/_jcr_data.binary
+++ b/ui.content/src/main/content/jcr_root/conf/wknd-shared/settings/graphql/persistentQueries/adventures-all/_jcr_content/_jcr_data.binary
@@ -10,6 +10,8 @@
         primaryImage {
           ... on ImageRef {
             _path
+            _authorUrl
+            _publishUrl
             mimeType
             width
             height

--- a/ui.content/src/main/content/jcr_root/conf/wknd-shared/settings/graphql/persistentQueries/adventures-by-activity/_jcr_content/_jcr_data.binary
+++ b/ui.content/src/main/content/jcr_root/conf/wknd-shared/settings/graphql/persistentQueries/adventures-by-activity/_jcr_content/_jcr_data.binary
@@ -20,6 +20,8 @@ query($activity: String!) {
         primaryImage {
           ... on ImageRef {
             _path
+            _authorUrl
+            _publishUrl
             mimeType
             width
             height


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Including the `_authorUrl` and `_publishUrl` for all image requests in persisted queries. This is useful for client applications to create an absolute path to images (instead of a relative one)
