### PR TITLE
Updated the correct rootpath

### DIFF
--- a/ui.content/src/main/content/jcr_root/conf/wknd-shared/settings/dam/cfm/models/adventure/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/wknd-shared/settings/dam/cfm/models/adventure/.content.xml
@@ -264,7 +264,7 @@
                             name="primaryImage"
                             nameSuffix="contentReference"
                             renderReadOnly="false"
-                            rootPath="/content/dam/wknd"
+                            rootPath="/content/dam/wknd-shared"
                             showEmptyInReadOnly="true"
                             showThumbnail="true"
                             validation="cfm.validation.contenttype.image"

--- a/ui.content/src/main/content/jcr_root/conf/wknd-shared/settings/dam/cfm/models/article/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/wknd-shared/settings/dam/cfm/models/article/.content.xml
@@ -96,7 +96,7 @@
                             name="featuredImage"
                             nameSuffix="contentReference"
                             renderReadOnly="false"
-                            rootPath="/content/dam/wknd"
+                            rootPath="/content/dam/wknd-shared"
                             showEmptyInReadOnly="true"
                             showThumbnail="true"
                             validation="cfm.validation.contenttype.image"
@@ -118,12 +118,12 @@
                             name="authorFragment"
                             nameSuffix="contentReference"
                             renderReadOnly="false"
-                            rootPath="/content/dam/wknd"
+                            rootPath="/content/dam/wknd-shared"
                             showEmptyInReadOnly="true"
                             valueType="string/content-fragment">
                             <field
                                 jcr:primaryType="nt:unstructured"
-                                rootPath="/content/dam/wknd"/>
+                                rootPath="/content/dam/wknd-shared"/>
                             <granite:data jcr:primaryType="nt:unstructured"/>
                         </_x0031_653589942228>
                         <_x0031_569504252173

--- a/ui.content/src/main/content/jcr_root/conf/wknd-shared/settings/dam/cfm/models/author/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/wknd-shared/settings/dam/cfm/models/author/.content.xml
@@ -91,7 +91,7 @@
                             nameSuffix="contentReference"
                             renderReadOnly="false"
                             required="on"
-                            rootPath="/content/dam/wknd"
+                            rootPath="/content/dam/wknd-shared"
                             showEmptyInReadOnly="true"
                             showThumbnail="true"
                             validation="cfm.validation.contenttype.image"


### PR DESCRIPTION
Updated the correct rooth path in cfm so that it points to wknd-shared and not wknd because wknd doesn't have author sample assets anymore

## Description
Since from wknd2.0.0 we are moving to a different content structure, in one of the cfm for asset browse, old rootpath was noticed which is now changed to the correct one.

## Related Issue
This change was needed so as to allow authors to be able to use the sample assets when authoring Author Content fragment.

## Motivation and Context

This change was needed so as to allow authors to be able to use the sample assets when authoring Author Content fragment.

## How Has This Been Tested?

The package of wknd 2.0.0 was installed in local as well as on AEM CS instance to reproduce the issue. 
After the fix it is tested again and seems to be working.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
